### PR TITLE
redisClient追加

### DIFF
--- a/benchmark/fetch2_test.go
+++ b/benchmark/fetch2_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spkills/spkills/config"
+	"github.com/spkills/spkills/model"
+)
+
+func BenchmarkFetchRoomNameByDB(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomNameByDB(1)
+	}
+}
+
+func BenchmarkFetchRoomNameByCache(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	model.InitCache()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomNameByCache(1)
+	}
+}
+
+func BenchmarkFetchRoomNameByRedis(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	model.InitRedis(conf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomNameByRedis(1)
+	}
+}

--- a/benchmark/fetch_test.go
+++ b/benchmark/fetch_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spkills/spkills/config"
+	"github.com/spkills/spkills/model"
+)
+
+func BenchmarkSelectByDb(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomByDB(1)
+	}
+}
+
+func BenchmarkSelectByCache(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	model.InitCache()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomByCache(1)
+	}
+}
+
+func BenchmarkSelectByRedis(b *testing.B) {
+	var conf config.Config
+	_, err := toml.DecodeFile("../config/config.toml", &conf)
+	if err != nil {
+		// Error Handling
+	}
+	model.InitDB(conf)
+	model.InitRedis(conf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		model.FetchRoomByRedis(1)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -16,4 +16,10 @@ type Config struct {
 		DbName       string `toml:"db_name"`
 		MaxIdleConns int    `toml:"max_idle_conns"`
 	} `toml:"database"`
+	Redis struct {
+		Server   string `toml:"server"`
+		Port     int    `toml:"port"`
+		DB       int    `toml:"db"`
+		Password string `toml:"password"`
+	} `toml:"redis"`
 }

--- a/config/config.toml
+++ b/config/config.toml
@@ -12,3 +12,9 @@ user = "isucon"
 password = "isucon"
 db_name = "isuketch"
 max_idle_conns = 10
+
+[redis]
+server = "127.0.0.1"
+port = 6379
+db = 0
+password = ""

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: f516362b669d6b214b748c7bc23ed78fc0e817c7ef7e562934ec75fe5f157195
-updated: 2017-09-24T23:01:34.53028526+09:00
+hash: 8ee27370ec12144e75c92cb2bc7d40f9854a3fae2b6a379b7c1602050712c531
+updated: 2017-09-27T00:04:29.732856675+09:00
 imports:
 - name: github.com/buaazp/fasthttprouter
   version: ade4e2031af3aed7fffd241084aad80a58faf421
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
+- name: github.com/go-redis/redis
+  version: 34ce349cb7b166233b5b56f441a6c0ac38c3da68
 - name: github.com/go-sql-driver/mysql
   version: 26471af196a17ee75a22e6481b5a5897fb16b081
 - name: github.com/klauspost/compress

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,3 +9,4 @@ import:
 - package: github.com/valyala/quicktemplate/qtc
 - package: github.com/volatiletech/sqlboiler
 - package: github.com/patrickmn/go-cache
+- package: github.com/go-redis/redis

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	model.InitDB(conf)
 	model.InitCache()
+	//model.InitRedis(conf) // redis起動してないと落ちる
 
 	router := fasthttprouter.New()
 

--- a/model/db.go
+++ b/model/db.go
@@ -9,6 +9,7 @@ import (
 	// use mysq
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spkills/spkills/config"
+	"github.com/volatiletech/sqlboiler/boil"
 )
 
 var db *sql.DB
@@ -34,7 +35,7 @@ func InitDB(conf config.Config) {
 		"Local",
 	)
 
-	log.Println(dsn)
+	//log.Println(dsn)
 
 	db, err = sql.Open("mysql", dsn)
 
@@ -47,4 +48,5 @@ func InitDB(conf config.Config) {
 	}
 
 	db.SetMaxIdleConns(conf.Database.MaxIdleConns)
+	boil.SetDB(db)
 }

--- a/model/redis.go
+++ b/model/redis.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-redis/redis"
+	"github.com/spkills/spkills/config"
+)
+
+var redisClient *redis.Client
+
+func InitRedis(conf config.Config) {
+	redisClient = redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%d", conf.Redis.Server, conf.Redis.Port),
+		Password: conf.Redis.Password,
+		DB:       conf.Redis.DB,
+	})
+	_, err := redisClient.Ping().Result()
+	if err != nil {
+		log.Panic(err)
+	}
+}

--- a/model/room.go
+++ b/model/room.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis"
+	"github.com/spkills/spkills/repository"
+)
+
+func FetchRoomByDB(roomId int) *repository.Room {
+	room, _ := repository.FindRoomG(int64(roomId))
+	return room
+}
+
+func FetchRoomByCache(roomId int) *repository.Room {
+	key := fmt.Sprintf("room:%d", roomId)
+	var room *repository.Room
+	var err error
+	val, found := Cache.Get(key)
+	if found {
+		room = val.(*repository.Room)
+		//fmt.Printf("cache(db)\n")
+	} else {
+		room, err = repository.FindRoomG(int64(roomId))
+		if err != nil {
+			//
+		}
+		Cache.Set(key, room, 10*time.Second)
+		//fmt.Printf("cache(cache)\n")
+	}
+	//fmt.Printf("cache %+v\n", room)
+	return room
+}
+
+func FetchRoomByRedis(roomId int) *repository.Room {
+	key := fmt.Sprintf("room:%d", roomId)
+	var room *repository.Room
+	var err error
+	val, err := redisClient.Get(key).Result()
+	if err == redis.Nil {
+		room, err = repository.FindRoomG(int64(roomId))
+		if err != nil {
+			//
+		}
+		// いったんjsonでbyteにしてから、文字列を渡す必要がある
+		out, err := json.Marshal(room)
+		if err != nil {
+			panic(err)
+		}
+		err = redisClient.Set(key, string(out), 10*time.Second).Err()
+		if err != nil {
+			panic(err)
+		}
+		//fmt.Printf("redis(db)\n")
+	} else if err != nil {
+		panic(err)
+	} else {
+		// いったん文字列をbyte配列にメモリコピーしてデシリアライズする
+		room = &repository.Room{}
+		err := json.Unmarshal([]byte(val), room)
+		if err != nil {
+			panic(err)
+		}
+		//fmt.Printf("redis(cache)\n")
+	}
+	//fmt.Printf("redis %+v\n", room)
+	return room
+}


### PR DESCRIPTION
redisのインストールと起動
```
$ brew install redis
$ redis-server /usr/local/etc/redis.conf
```

ベンチマークの実行
```
$ go test -bench . -benchmem ./benchmark/...
goos: darwin
goarch: amd64
pkg: github.com/spkills/spkills/benchmark
BenchmarkSelectByDb-4      	   10000	    115465 ns/op	    1829 B/op	      39 allocs/op
BenchmarkSelectByCache-4   	10000000	       140 ns/op	      16 B/op	       2 allocs/op
BenchmarkSelectByRedis-4   	   30000	     43785 ns/op	    1024 B/op	      18 allocs/op
PASS
ok  	github.com/spkills/spkills/benchmark	4.512s
```

### 所感
プロセスキャッシュの圧倒的なキャッシュ力。
redisはもっと早いかと思ったけど、json.Marshal, json.UnMarshalのコストが重いのかもしれない。

redisに構造体をSet／Getするのがなかなかだるい。
そしてredisとcacheのSet／Getで戻り値違うのもだるい。
かと言って透過的に扱えるようにするラッパーを実装するのもだるそうな雰囲気ある。
もうとにかくだるい。
