### PR TITLE
redisもunixドメインソケットで接続

### DIFF
--- a/benchmark/fetch_test.go
+++ b/benchmark/fetch_test.go
@@ -15,6 +15,8 @@ func BenchmarkSelectByDb(b *testing.B) {
 		// Error Handling
 	}
 	model.InitDB(conf)
+	model.InitCache()
+	model.InitRedis(conf)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		model.FetchRoomByDB(1)
@@ -29,6 +31,7 @@ func BenchmarkSelectByCache(b *testing.B) {
 	}
 	model.InitDB(conf)
 	model.InitCache()
+	model.InitRedis(conf)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		model.FetchRoomByCache(1)
@@ -42,6 +45,7 @@ func BenchmarkSelectByRedis(b *testing.B) {
 		// Error Handling
 	}
 	model.InitDB(conf)
+	model.InitCache()
 	model.InitRedis(conf)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/config/config.go
+++ b/config/config.go
@@ -17,9 +17,10 @@ type Config struct {
 		MaxIdleConns int    `toml:"max_idle_conns"`
 	} `toml:"database"`
 	Redis struct {
-		Server   string `toml:"server"`
-		Port     int    `toml:"port"`
-		DB       int    `toml:"db"`
-		Password string `toml:"password"`
+		Server     string `toml:"server"`
+		Port       int    `toml:"port"`
+		DB         int    `toml:"db"`
+		Password   string `toml:"password"`
+		SocketFile string `toml:"socket_file"`
 	} `toml:"redis"`
 }

--- a/config/config.toml
+++ b/config/config.toml
@@ -18,3 +18,4 @@ server = "127.0.0.1"
 port = 6379
 db = 0
 password = ""
+socket_file = "/tmp/redis.sock"

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,18 @@
-hash: 8ee27370ec12144e75c92cb2bc7d40f9854a3fae2b6a379b7c1602050712c531
-updated: 2017-09-27T00:04:29.732856675+09:00
+hash: 29b7ca7c351dca199250264b7846d26aa6a16742a69583d3b775add289f7e6df
+updated: 2017-10-01T17:24:51.999498681+09:00
 imports:
 - name: github.com/buaazp/fasthttprouter
   version: ade4e2031af3aed7fffd241084aad80a58faf421
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - name: github.com/go-redis/redis
-  version: 34ce349cb7b166233b5b56f441a6c0ac38c3da68
+  version: 9c20773cb24624a4ad05cddb60583b61f4ffa701
+  subpackages:
+  - internal
+  - internal/consistenthash
+  - internal/hashtag
+  - internal/pool
+  - internal/proto
 - name: github.com/go-sql-driver/mysql
   version: 26471af196a17ee75a22e6481b5a5897fb16b081
 - name: github.com/klauspost/compress
@@ -23,6 +29,10 @@ imports:
   version: 2b3a18b5f0fb6b4f9190549597d3f962c02bc5eb
 - name: github.com/rmanzoku/friction
   version: 9f71726225d839465b5612433b0ea845aa2834d8
+- name: github.com/ugorji/go
+  version: 54210f4e076c57f351166f0ed60e67d3fca57a36
+  subpackages:
+  - codec
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,3 +10,4 @@ import:
 - package: github.com/volatiletech/sqlboiler
 - package: github.com/patrickmn/go-cache
 - package: github.com/go-redis/redis
+- package: github.com/ugorji/go/codec

--- a/model/redis.go
+++ b/model/redis.go
@@ -3,6 +3,8 @@ package model
 import (
 	"fmt"
 	"log"
+	"net"
+	"os"
 
 	"github.com/go-redis/redis"
 	"github.com/spkills/spkills/config"
@@ -11,13 +13,33 @@ import (
 var redisClient *redis.Client
 
 func InitRedis(conf config.Config) {
+	var addr string
+	var network string
+	var dialer func() (net.Conn, error)
+	_, err := os.Stat(conf.Database.SocketFile)
+	if err == nil {
+		network = "unix"
+		dialer = func() (net.Conn, error) {
+			conn, err := net.Dial("unix", conf.Redis.SocketFile)
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
+			return conn, err
+		}
+	} else {
+		network = "tcp"
+		addr = fmt.Sprintf("%s:%s", conf.Redis.Server, conf.Redis.Port)
+	}
+
 	redisClient = redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", conf.Redis.Server, conf.Redis.Port),
+		Addr:     addr,
 		Password: conf.Redis.Password,
 		DB:       conf.Redis.DB,
+		Network:  network,
+		Dialer:   dialer,
 	})
-	_, err := redisClient.Ping().Result()
-	if err != nil {
-		log.Panic(err)
-	}
+	// _, err := redisClient.Ping().Result()
+	// if err != nil {
+	// 	log.Panic(err)
+	// }
 }

--- a/model/redis.go
+++ b/model/redis.go
@@ -13,13 +13,13 @@ var redisClient *redis.Client
 func InitRedis(conf config.Config) {
 	var addr string
 	var network string
-	_, err := os.Stat(conf.Database.SocketFile)
+	_, err := os.Stat(conf.Redis.SocketFile)
 	if err == nil {
 		network = "unix"
 		addr = conf.Redis.SocketFile
 	} else {
 		network = "tcp"
-		addr = fmt.Sprintf("%s:%s", conf.Redis.Server, conf.Redis.Port)
+		addr = fmt.Sprintf("%s:%d", conf.Redis.Server, conf.Redis.Port)
 	}
 
 	redisClient = redis.NewClient(&redis.Options{

--- a/model/redis.go
+++ b/model/redis.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"fmt"
-	"log"
-	"net"
 	"os"
 
 	"github.com/go-redis/redis"
@@ -15,17 +13,10 @@ var redisClient *redis.Client
 func InitRedis(conf config.Config) {
 	var addr string
 	var network string
-	var dialer func() (net.Conn, error)
 	_, err := os.Stat(conf.Database.SocketFile)
 	if err == nil {
 		network = "unix"
-		dialer = func() (net.Conn, error) {
-			conn, err := net.Dial("unix", conf.Redis.SocketFile)
-			if err != nil {
-				log.Fatalf("error: %v", err)
-			}
-			return conn, err
-		}
+		addr = conf.Redis.SocketFile
 	} else {
 		network = "tcp"
 		addr = fmt.Sprintf("%s:%s", conf.Redis.Server, conf.Redis.Port)
@@ -36,7 +27,6 @@ func InitRedis(conf config.Config) {
 		Password: conf.Redis.Password,
 		DB:       conf.Redis.DB,
 		Network:  network,
-		Dialer:   dialer,
 	})
 	// _, err := redisClient.Ping().Result()
 	// if err != nil {


### PR DESCRIPTION
### 単純なGet/Set
50,000から100,000に改善された 👍 
```
$ go test -bench Fetch -benchmem ./benchmark/...
goos: darwin
goarch: amd64
pkg: github.com/spkills/spkills/benchmark
BenchmarkFetchRoomNameByDB-4      	   10000	    113353 ns/op	    1830 B/op	      39 allocs/op
BenchmarkFetchRoomNameByCache-4   	10000000	       159 ns/op	      24 B/op	       2 allocs/op
BenchmarkFetchRoomNameByRedis-4   	  100000	     17658 ns/op	     272 B/op	       9 allocs/op
```

### 構造体のGet/Set
30,000から50,000に改善された
```
go test -bench Select -benchmem ./benchmark/...
goos: darwin
goarch: amd64
pkg: github.com/spkills/spkills/benchmark
BenchmarkSelectByDb-4      	   10000	    119045 ns/op	    1829 B/op	      39 allocs/op
BenchmarkSelectByCache-4   	10000000	       138 ns/op	      16 B/op	       2 allocs/op
BenchmarkSelectByRedis-4   	   50000	     23632 ns/op	    1024 B/op	      18 allocs/op
PASS
```


構造体のGet/Setで伸び悩んだのを見ると、やっぱりシリアライザの処理がボトルネックっぽい。


#### その他
redisのconf(`/usr/local/etc/redis.conf`)でsocketの項目を有効にしてください。
unixsocket /tmp/redis.sock
unixsocketperm 755
