### PR TITLE
redisに突っ込むbyte配列をmessage packにした

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,18 @@
-hash: 8ee27370ec12144e75c92cb2bc7d40f9854a3fae2b6a379b7c1602050712c531
-updated: 2017-09-27T00:04:29.732856675+09:00
+hash: 29b7ca7c351dca199250264b7846d26aa6a16742a69583d3b775add289f7e6df
+updated: 2017-10-01T17:24:51.999498681+09:00
 imports:
 - name: github.com/buaazp/fasthttprouter
   version: ade4e2031af3aed7fffd241084aad80a58faf421
 - name: github.com/BurntSushi/toml
   version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - name: github.com/go-redis/redis
-  version: 34ce349cb7b166233b5b56f441a6c0ac38c3da68
+  version: 9c20773cb24624a4ad05cddb60583b61f4ffa701
+  subpackages:
+  - internal
+  - internal/consistenthash
+  - internal/hashtag
+  - internal/pool
+  - internal/proto
 - name: github.com/go-sql-driver/mysql
   version: 26471af196a17ee75a22e6481b5a5897fb16b081
 - name: github.com/klauspost/compress
@@ -23,6 +29,10 @@ imports:
   version: 2b3a18b5f0fb6b4f9190549597d3f962c02bc5eb
 - name: github.com/rmanzoku/friction
   version: 9f71726225d839465b5612433b0ea845aa2834d8
+- name: github.com/ugorji/go
+  version: 54210f4e076c57f351166f0ed60e67d3fca57a36
+  subpackages:
+  - codec
 - name: github.com/valyala/bytebufferpool
   version: e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7
 - name: github.com/valyala/fasthttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,3 +10,4 @@ import:
 - package: github.com/volatiletech/sqlboiler
 - package: github.com/patrickmn/go-cache
 - package: github.com/go-redis/redis
+- package: github.com/ugorji/go/codec

--- a/model/redis.go
+++ b/model/redis.go
@@ -13,13 +13,13 @@ var redisClient *redis.Client
 func InitRedis(conf config.Config) {
 	var addr string
 	var network string
-	_, err := os.Stat(conf.Database.SocketFile)
+	_, err := os.Stat(conf.Redis.SocketFile)
 	if err == nil {
 		network = "unix"
 		addr = conf.Redis.SocketFile
 	} else {
 		network = "tcp"
-		addr = fmt.Sprintf("%s:%s", conf.Redis.Server, conf.Redis.Port)
+		addr = fmt.Sprintf("%s:%d", conf.Redis.Server, conf.Redis.Port)
 	}
 
 	redisClient = redis.NewClient(&redis.Options{


### PR DESCRIPTION
### 構造体のGet/Set
ソケット接続との合わせ技で30,000から100,000に改善された 👍 
```
go test -bench Select -benchmem ./benchmark/...
goos: darwin
goarch: amd64
pkg: github.com/spkills/spkills/benchmark
BenchmarkSelectByDb-4      	   10000	    113650 ns/op	    1829 B/op	      39 allocs/op
BenchmarkSelectByCache-4   	10000000	       146 ns/op	      16 B/op	       2 allocs/op
BenchmarkSelectByRedis-4   	  100000	     22021 ns/op	    3721 B/op	      16 allocs/op
PASS
```

### 参考
[汎用シリアライズ方法(MessagePack/Protocol Buffers/FlatBuffers)のGoでのベンチマーク](https://www.sambaiz.net/article/46/)
[最速という噂のFlatbuffersの速度のヒミツと、導入方法の紹介(Go)](https://qiita.com/shibukawa/items/878c5fe8ec09935fccd2)

`Flatbuffers`は早そうだけど、保存するスキーマを別途用意しないといけないのがなぁと思って`MessagePack`の方にした。

[Go の msgpack ライブラリ比較](https://qiita.com/yosisa/items/f21d3476bc8d368d7494)
> 基本的には github.com/ugorji/go/codec を使うのが良さそうです。

って書いてたのでライブラリはそれ使った。

